### PR TITLE
(SIMP-7974) Demonstrate new GLCI pipeline features

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,4 @@
 # ------------------------------------------------------------------------------
-#             NOTICE: **This file is maintained with puppetsync**
-# ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
 # https://puppet.com/docs/pe/2019.8/component_versions_in_recent_pe_releases.html
@@ -30,6 +28,7 @@ variables:
   BUNDLE_PATH:       .vendor/bundle
   BUNDLE_BIN:        .vendor/gem_install/bin
   BUNDLE_NO_PRUNE:   'true'
+  SIMP_MATRIX_LEVEL: '1'
 
 
 # bundler dependencies and caching
@@ -52,12 +51,85 @@ variables:
     - 'rm -rf pkg/ || :'
     - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || { echo "PIPELINE: Bundler could not install everything (see log output above)" && exit 99 ; }'
 
-# To avoid running a prohibitive number of tests every commit,
-# don't set this env var in your gitlab instance
-.only_with_SIMP_FULL_MATRIX: &only_with_SIMP_FULL_MATRIX
-  only:
-    variables:
-      - $SIMP_FULL_MATRIX == "yes"
+# Assign a matrix level when your test will run.  Heavier jobs get higher numbers
+# NOTE: To skip all jobs with a SIMP_MATRIX_LEVEL, set SIMP_MATRIX_LEVEL=0
+
+.meets_spec_test_criteria: &meets_spec_test_criteria
+  changes:
+    - .gitlab-ci.yml
+    - .fixtures.yml
+    - "spec/spec_helper.rb"
+    - "spec/{classes,unit,defines}/**/*.rb"
+    - "{manifests,files,types}/**/*"
+    - "templates/*.{erb,epp}"
+    - "lib/**/*"
+  exists:
+    - "spec/{classes,unit,defines}/**/*_spec.rb"
+
+.meets_acceptance_test_criteria: &meets_acceptance_test_criteria
+  changes:
+    - .gitlab-ci.yml
+    - "spec/spec_helper_acceptance.rb"
+    - "spec/acceptance/**/*"
+    - "{manifests,files,types}/**/*"
+    - "templates/*.{erb,epp}"
+    - "lib/**/*"
+  exists:
+    - "spec/acceptance/**/*_spec.rb"
+
+# SIMP_MATRIX_LEVEL=1: Intended to run every commit
+.with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1: &with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  rules:
+    - when: on_success
+      if: '$CI_COMMIT_MESSAGE =~ /^CI: MATRIX LEVEL [123]/'
+    - when: on_success
+      if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL =~ /^[123]$/'
+    - when: on_success
+      if: '$SIMP_MATRIX_LEVEL =~ /^[123]$/ && $CI_COMMIT_MESSAGE !~ /^CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
+      <<: *meets_acceptance_test_criteria
+
+.with_SIMP_SPEC_MATRIX_LEVEL_1: &with_SIMP_SPEC_MATRIX_LEVEL_1
+  rules:
+    - when: on_success
+      if: '$CI_COMMIT_MESSAGE =~ /^CI: MATRIX LEVEL [123]/'
+    - when: on_success
+      if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL =~ /^[123]$/'
+    - when: on_success
+      if: '$SIMP_MATRIX_LEVEL =~ /^[123]$/ && $CI_COMMIT_MESSAGE !~ /^CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
+      <<: *meets_spec_test_criteria
+
+# SIMP_MATRIX_LEVEL=2: Resource-heavy or redundant jobs
+.with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2: &with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  rules:
+    - when: on_success
+      if: '$CI_COMMIT_MESSAGE =~ /^CI: MATRIX LEVEL [23]/'
+    - when: on_success
+      if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL =~ /^[23]$/'
+    - when: on_success
+      if: '$SIMP_MATRIX_LEVEL =~ /^[23]$/ && $CI_COMMIT_MESSAGE !~ /^CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
+      <<: *meets_acceptance_test_criteria
+
+.with_SIMP_SPEC_MATRIX_LEVEL_2: &with_SIMP_SPEC_MATRIX_LEVEL_2
+  rules:
+    - when: on_success
+      if: '$CI_COMMIT_MESSAGE =~ /^CI: MATRIX LEVEL [23]/'
+    - when: on_success
+      if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL =~ /^[23]$/'
+    - when: on_success
+      if: '$SIMP_MATRIX_LEVEL =~ /^[23]$/ && $CI_COMMIT_MESSAGE !~ /^CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
+      <<: *meets_spec_test_criteria
+
+# SIMP_MATRIX_LEVEL=3: Reserved for FULL matrix testing
+.with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3: &with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  rules:
+    - when: on_success
+      if: '$CI_COMMIT_MESSAGE =~ /^CI: MATRIX LEVEL 3/'
+    - when: on_success
+      if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL == "3"'
+    - when: on_success
+      if: '$SIMP_MATRIX_LEVEL =~ /^3$/ && $CI_COMMIT_MESSAGE !~ /^CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
+      <<: *meets_acceptance_test_criteria
+
 
 # Puppet Versions
 #-----------------------------------------------------------------------
@@ -106,6 +178,7 @@ variables:
   stage: 'validation'
   tags: ['docker']
   <<: *setup_bundler_env
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_1
   script:
     - 'bundle exec rake spec'
 
@@ -113,11 +186,13 @@ variables:
   stage: 'acceptance'
   tags: ['beaker']
   <<: *setup_bundler_env
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
 
 .compliance_base: &compliance_base
   stage: 'compliance'
   tags: ['beaker']
   <<: *setup_bundler_env
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
 
 
 # Pipeline / testing matrix
@@ -186,19 +261,21 @@ pup5.5.17-fips:
 pup5.5.17-oel:
   <<: *pup_5_5_17
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
 pup5.5.17-oel-fips:
   <<: *pup_5_5_17
   <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
 pup6:
   <<: *pup_6
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
@@ -235,13 +312,14 @@ pup6.16.0-fips:
 pup6.16.0-oel:
   <<: *pup_6_16_0
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
 pup6.16.0-oel-fips:
   <<: *pup_6_16_0
   <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 


### PR DESCRIPTION
The patch demonstrates new features for SIMP Puppet modules' standard
GitLab CI pipeline:

* spec and acceptance tests _only_ run when relevant files have changed
* The CI variable `SIMP_FULL_MATRIX` is replaced by `SIMP_MATRIX_LEVEL`
* spec and acceptance tests run at or above their `SIMP_MATRIX_LEVEL`
* Jobs and the pipeline default to `SIMP_MATRIX_LEVEL` 1
* The pipeline's `SIMP_MATRIX_LEVEL` can be changed via CI variable
  (via triggers, group/project settings, etc)
* In the pipeline-triggering commit message, adding a line that starts
  with `CI: MATRIX LEVEL 0` or `CI: SKIP MATRIX` will suppress all steps
  with `SIMP_MATRIX_LEVEL` 1-3

There is an important caveat: because of the way GitLab CI pipelines
determine `changes`, a file that hasn't changed between `--amend` +
force-pushed updates _will not trigger the matrix again_.  This affects
scheduled and triggered pipelines.

* To address this scenario, setting the CI variable `SIMP_FORCE_MATRIX =
  yes` in a scheduled pipeline or pipeline trigger will ensure that all
  jobs at the current `SIMP_MATRIX_LEVEL` are run, regardless of what
  has changed (or not).

SIMP-7976 #close
[SIMP-7974] #comment demonstrate in pupmod-simp-dummy
[SIMP-7975] #close #comment demonstrate in pupmod-simp-dummy

[SIMP-7974]: https://simp-project.atlassian.net/browse/SIMP-7974
[SIMP-7975]: https://simp-project.atlassian.net/browse/SIMP-7975